### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ This project is an MCP (Model Context Protocol) server built to interact with th
 
 It allows clients like **Claude AI** to search, explore, and compare arXiv papers efficiently — all through a custom-built, local server. It’s built with **Python** and the **FastMCP** framework, and uses **uv** for lightweight package management.
 
+<a href="https://glama.ai/mcp/servers/@daheepk/arxiv-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@daheepk/arxiv-mcp-server/badge" alt="arXiv Research Assistant Server MCP server" />
+</a>
+
 ---
-S
 ## ✨ Features
 
 - **🔍 Keyword-based Paper Search**  


### PR DESCRIPTION
This PR adds a badge for the [arXiv Research Assistant MCP Server](https://glama.ai/mcp/servers/@daheepk/arxiv-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@daheepk/arxiv-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@daheepk/arxiv-mcp-server/badge" alt="arXiv Research Assistant Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.